### PR TITLE
Specify the language used in the site as English

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -31,7 +31,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <Html>
+      <Html lang="en">
         <Head>
           <link
             href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"


### PR DESCRIPTION
allow non-English speaking screen-reader users to understand the content:
https://web.dev/html-has-lang/
